### PR TITLE
Add: LINE公式アカウントの作成、LINE Messaging APIとの通信を行うコントローラの追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@
 /node_modules
 
 /public/.DS_Store
+
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,9 @@ gem 'sorcery'
 # LINE Messaging API SDK for Ruby
 gem 'line-bot-api'
 
+# 環境変数の管理
+gem 'dotenv'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]

--- a/Gemfile
+++ b/Gemfile
@@ -70,7 +70,7 @@ gem 'sorcery'
 gem 'line-bot-api'
 
 # 環境変数の管理
-gem 'dotenv'
+gem 'dotenv-rails'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,9 @@ gem 'jsbundling-rails'
 # ログイン機能
 gem 'sorcery'
 
+# LINE Messaging API SDK for Ruby
+gem 'line-bot-api'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,9 @@ GEM
     diff-lcs (1.5.0)
     digest (3.1.0)
     dotenv (2.7.6)
+    dotenv-rails (2.7.6)
+      dotenv (= 2.7.6)
+      railties (>= 3.2)
     enum_help (0.0.19)
       activesupport (>= 3.0.0)
     erubi (1.10.0)
@@ -318,7 +321,7 @@ DEPENDENCIES
   capybara
   cssbundling-rails
   debug
-  dotenv
+  dotenv-rails
   enum_help
   factory_bot_rails
   html2slim

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,6 +126,7 @@ GEM
       railties (>= 6.0.0)
     json (2.6.2)
     jwt (2.4.1)
+    line-bot-api (1.25.0)
     loofah (2.18.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -321,6 +322,7 @@ DEPENDENCIES
   html2slim
   jbuilder
   jsbundling-rails
+  line-bot-api
   pg (~> 1.1)
   pry-rails
   puma (~> 5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,7 @@ GEM
       reline (>= 0.2.7)
     diff-lcs (1.5.0)
     digest (3.1.0)
+    dotenv (2.7.6)
     enum_help (0.0.19)
       activesupport (>= 3.0.0)
     erubi (1.10.0)
@@ -317,6 +318,7 @@ DEPENDENCIES
   capybara
   cssbundling-rails
   debug
+  dotenv
   enum_help
   factory_bot_rails
   html2slim

--- a/app/controllers/line_messaging_api_controller.rb
+++ b/app/controllers/line_messaging_api_controller.rb
@@ -1,0 +1,50 @@
+class LineMessagingApiController < ApplicationController
+  require 'line/bot'
+  # 外部からのPOSTリクエストを受けるためにCSRF対策を外す
+  protect_from_forgery except: :callback
+  skip_before_action :require_login
+
+  def callback
+    body = request.body.read
+    signature = request.env['HTTP_X_LINE_SIGNATURE']
+    unless client.validate_signature(body, signature)
+      header_only(:bad_request)
+    end
+
+    events = client.parse_events_from(body)
+
+    events.each do |event|
+      case event
+      when Line::Bot::Event::Message
+        case event.type
+        when Line::Bot::Event::MessageType::Text
+          line_user_id = event['source']['userId']
+          message = {
+            type: 'text',
+            text: event.message['text']
+          }
+          client.push_message(line_user_id, message)
+        end
+      end
+    end
+    head :ok
+  end
+
+  def send_broadcast_message(text)
+    message = {
+      type: 'text',
+      text: text
+    }
+    client.broadcast(message)
+  end
+
+  private
+
+  def client
+    @client ||= Line::Bot::Client.new { |config|
+      config.channel_id = ENV["LINE_CHANNEL_ID"]
+      config.channel_secret = ENV["LINE_CHANNEL_SECRET"]
+      config.channel_token = ENV["LINE_CHANNEL_TOKEN"]
+    }
+  end
+end

--- a/app/controllers/line_users_controller.rb
+++ b/app/controllers/line_users_controller.rb
@@ -10,4 +10,7 @@ class LineUsersController < ApplicationController
 
   def destroy
   end
+
+  def callback
+  end
 end

--- a/app/models/line_messaging_api.rb
+++ b/app/models/line_messaging_api.rb
@@ -1,0 +1,23 @@
+# アプリとLINE Messaging APIの間で通信を行うモデル
+# https://github.com/line/line-bot-sdk-ruby
+
+require 'line/bot'
+
+class LineMessagingApi
+
+  def client
+    @client ||= Line::Bot::Client.new { |config|
+      config.channel_id = ENV["LINE_CHANNEL_ID"]
+      config.channel_secret = ENV["LINE_CHANNEL_SECRET"]
+      config.channel_token = ENV["LINE_CHANNEL_TOKEN"]
+    }
+  end
+
+  def send_broadcast_message(text)
+    message = {
+      type: 'text',
+      text: text
+    }
+    client.broadcast(message)
+  end
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -67,4 +67,9 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+
+  # LINE Messaging APIを開発環境でテストするため
+  # ngrokで起動したサーバーを許可する
+  # https://www.codegrepper.com/code-examples/ruby/rails+ngrok+blocked+host
+  config.hosts << 'd4ac-240b-251-9460-9600-cc27-f68d-df04-fa4d.jp.ngrok.io'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,4 +28,5 @@ Rails.application.routes.draw do
 
   # LINEユーザー
   resources :line_users, only: %i(index new create destroy)
+  post '/callback', to: 'line_messaging_api#callback'
 end

--- a/lib/tasks/send_line_message.rake
+++ b/lib/tasks/send_line_message.rake
@@ -1,7 +1,7 @@
 namespace :send_line_message do
   desc 'LINEメッセージを送信する'
 	task send_test_message: :environment do
-		request = LineMessagingApi.new
-    request.send_broadcast_message('test message')
+		controller = LineMessagingApiController.new
+    controller.send_broadcast_message('test message')
 	end
 end

--- a/lib/tasks/send_line_message.rake
+++ b/lib/tasks/send_line_message.rake
@@ -1,6 +1,7 @@
 namespace :send_line_message do
   desc 'LINEメッセージを送信する'
 	task send_test_message: :environment do
-		puts 'hello'
+		request = LineMessagingApi.new
+    request.send_broadcast_message('test message')
 	end
 end

--- a/lib/tasks/send_line_message.rake
+++ b/lib/tasks/send_line_message.rake
@@ -1,0 +1,6 @@
+namespace :send_line_message do
+  desc 'LINEメッセージを送信する'
+	task send_test_message: :environment do
+		puts 'hello'
+	end
+end


### PR DESCRIPTION
# issue
close #39 

# 内容
・  100c1d0a78c4836f2bd4cc00bebc0cf8f2d2ae3c にて、gem `line-bot-api`を追加した
・  e78721a710a6664b162c4d6ae5e86c1a716acd48 fa38f3be9670523b2de75a769ad35e4881e44d93 ef8291b50d3d99521566c5e1d10c6482e54117c0 にて、環境変数を管理するgem `dotenv-rails`を追加した
・ ed453c67709684ff8e82df4c17873dfd55f78666 aea9b27a21ff3f2ed74c42f4078930e84336a2d2 bc1aaed457a60a600e09db0244ad5a83e4d34524 にて、LINE Messaging APIとの通信を行うコントローラと、確認用のrakeタスクを追加した

# 確認方法
・コマンドで`bundle exec rake send_line_message:send_test_message`を実行し、自分のLINEアカウントにメッセージが送信されていることを確認する
・自分のLINEアカウントから「トリコミ」LINEアカウント宛にメッセージを送信し、メッセージが返信されることを確認する

# 確認結果
![21D01BCB-D68C-4CED-A20C-F1DC4B3298A4](https://user-images.githubusercontent.com/97581501/179680839-4bcdcf40-af8b-4350-978b-4a571b81d33b.jpg)

# 備考
・localhost:3000に外部からアクセスするため、ngrokを使用した。 678cca47b3780ea3633995363962f9f18cf29dea にて、ngrokで起動したサーバーにアクセスできるようにするため、`config/environments/development.rb`内のhostsの設定を変更した。
・LineMessagingApiコントローラのCSRF対策は #43 にて対応する。