### PR TITLE
Add: スケジュール作成・更新・削除時にLINE送信ジョブを操作する機能を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,7 +67,6 @@ gem 'jsbundling-rails'
 gem 'sorcery'
 
 # LINE Messaging API
-
 gem 'line-bot-api'
 gem 'typhoeus'
 
@@ -76,6 +75,9 @@ gem 'dotenv-rails'
 
 # アプリユーザーとLINEユーザーを紐付けるために利用するワンタイムパスワードライブラリ
 gem 'rotp'
+
+# LINEメッセージ送信の非同期処理を行う
+gem 'sidekiq'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,7 @@ GEM
     childprocess (4.1.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
+    connection_pool (2.2.5)
     crass (1.0.6)
     cssbundling-rails (1.1.1)
       railties (>= 6.0.0)
@@ -220,6 +221,7 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.0.6)
+    redis (4.7.1)
     regexp_parser (2.5.0)
     reline (0.3.1)
       io-console (~> 0.5)
@@ -266,6 +268,10 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    sidekiq (6.5.1)
+      connection_pool (>= 2.2.2)
+      rack (~> 2.0)
+      redis (>= 4.2.0)
     slim (4.1.0)
       temple (>= 0.7.6, < 0.9)
       tilt (>= 2.0.6, < 2.1)
@@ -343,6 +349,7 @@ DEPENDENCIES
   rspec-rails
   rubocop
   rubocop-rails
+  sidekiq
   slim-rails
   sorcery
   sprockets-rails

--- a/app/controllers/line_messaging_api_controller.rb
+++ b/app/controllers/line_messaging_api_controller.rb
@@ -65,6 +65,17 @@ class LineMessagingApiController < ApplicationController
     client.broadcast(message)
   end
 
+  def send_push_message_by_schedule_id(schedule_id)
+    schedule = Schedule.find(schedule_id)
+    message = {
+      type: 'text',
+      text: schedule.title #あとで修正する
+    }
+    schedule.user.line_users.each do |line_user|
+      client.push_message(line_user.line_user_id, message)
+    end
+  end
+
   private
 
   def client

--- a/app/controllers/line_messaging_api_controller.rb
+++ b/app/controllers/line_messaging_api_controller.rb
@@ -69,7 +69,7 @@ class LineMessagingApiController < ApplicationController
     schedule = Schedule.find(schedule_id)
     message = {
       type: 'text',
-      text: schedule.title #あとで修正する
+      text: schedule.create_line_message
     }
     schedule.user.line_users.each do |line_user|
       client.push_message(line_user.line_user_id, message)

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -10,6 +10,7 @@ class SchedulesController < ApplicationController
   def create
     @schedule = current_user.schedules.new(schedule_params)
     if @schedule.save
+      SendLineMessageJob.perform_later(@schedule.id)
       redirect_to schedules_path, success: t('.success')
     else
       flash.now[:error] = t('.fail')

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -10,7 +10,8 @@ class SchedulesController < ApplicationController
   def create
     @schedule = current_user.schedules.new(schedule_params)
     if @schedule.save
-      SendLineMessageJob.perform_later(@schedule.id)
+      # スケジュール開始時間からユーザーが設定した分数だけ前に、LINEメッセージを送信するジョブを追加
+      SendLineMessageJob.set(wait_until: schedule.start_time - schedule.user.setting.notification_time*60).perform_later(@schedule.id)
       redirect_to schedules_path, success: t('.success')
     else
       flash.now[:error] = t('.fail')

--- a/app/jobs/send_line_message_job.rb
+++ b/app/jobs/send_line_message_job.rb
@@ -1,0 +1,7 @@
+class SendLineMessageJob < ApplicationJob
+  queue_as :default
+
+  def perform(*args)
+    # Do something later
+  end
+end

--- a/app/jobs/send_line_message_job.rb
+++ b/app/jobs/send_line_message_job.rb
@@ -1,7 +1,8 @@
 class SendLineMessageJob < ApplicationJob
   queue_as :default
 
-  def perform(*args)
-    puts 'hello'
+  def perform(*arg)
+    controller = LineMessagingApiController.new
+    controller.send_push_message_by_schedule_id(arg[0])
   end
 end

--- a/app/jobs/send_line_message_job.rb
+++ b/app/jobs/send_line_message_job.rb
@@ -2,6 +2,6 @@ class SendLineMessageJob < ApplicationJob
   queue_as :default
 
   def perform(*args)
-    # Do something later
+    puts 'hello'
   end
 end

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -4,4 +4,27 @@ class Schedule < ApplicationRecord
   validates :title, presence: true, length: { maximum: 255 }
   validates :body, length: { maximum: 65535 }
   validates :start_time, presence: true
+
+  def create_line_message
+    setting = self.user.setting
+
+    message = "スケジュールをお知らせします！" + "\n"
+
+    if setting.only_time?
+      message << "\n" + "日時：" + self.start_time.strftime('%Y年%m月%d日 %H時%M分')
+    elsif setting.time_and_title?
+      message << "\n" + "日時：" + self.start_time.strftime('%Y年%m月%d日 %H時%M分')
+      message << "\n" + "タイトル：" + self.title
+    else # setting.time_and_title_and_body?
+      message << "\n" + "日時：" + self.start_time.strftime('%Y年%m月%d日 %H時%M分')
+      message << "\n" + "タイトル：" + self.title
+      message << "\n" + "内容：" + self.body ||= "（未設定）"
+    end
+
+    if setting.message_text.present?
+      message << "\n\n" + setting.message_text
+    end
+
+    message
+  end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -52,5 +52,8 @@ module Torikomi
 
     #デフォルトのタイムゾーンを日本にする
     config.time_zone = 'Tokyo'
+
+    # Active Jobをsidekiqで実行する
+    config.active_job.queue_adapter = :sidekiq
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -71,5 +71,5 @@ Rails.application.configure do
   # LINE Messaging APIを開発環境でテストするため
   # ngrokで起動したサーバーを許可する
   # https://www.codegrepper.com/code-examples/ruby/rails+ngrok+blocked+host
-  config.hosts << 'ea6f-240b-251-9460-9600-cdf4-8cb5-4d30-31d3.jp.ngrok.io'
+  config.hosts << '6ac5-240b-251-9460-9600-cdf4-8cb5-4d30-31d3.jp.ngrok.io'
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,7 @@
+Sidekiq.configure_server do |config|
+  config.redis = { url: 'redis://127.0.0.1:6379' }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = { url: 'redis://127.0.0.1:6379' }
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,27 @@
+# ログの出力
+:logfile: ./log/sidekiq.log
+
+# 以下、https://github.com/mperham/sidekiq/blob/main/examples/config.yml より
+# Sample configuration file for Sidekiq.
+# Options here can still be overridden by cmd line args.
+# Place this file at config/sidekiq.yml and Sidekiq will
+# pick it up automatically.
+# ---
+# :verbose: false
+# :concurrency: 10
+# :timeout: 25
+
+# Sidekiq will run this file through ERB when reading it so you can
+# even put in dynamic logic, like a host-specific queue.
+# http://www.mikeperham.com/2013/11/13/advanced-sidekiq-host-specific-queues/
+# :queues:
+#  - critical
+#   - default
+#   - <%= `hostname`.strip %>
+#   - low
+
+# you can override concurrency based on environment
+# production:
+#   :concurrency: 25
+# staging:
+#   :concurrency: 15

--- a/db/migrate/20220721060203_add_job_id_to_schedules.rb
+++ b/db/migrate/20220721060203_add_job_id_to_schedules.rb
@@ -1,0 +1,5 @@
+class AddJobIdToSchedules < ActiveRecord::Migration[7.0]
+  def change
+    add_column :schedules, :job_id, :string, null: false, default: ''
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_07_20_042520) do
+ActiveRecord::Schema[7.0].define(version: 2022_07_21_060203) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -33,6 +33,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_20_042520) do
     t.datetime "end_time", precision: nil
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "job_id", default: "", null: false
     t.index ["user_id"], name: "index_schedules_on_user_id"
   end
 

--- a/spec/jobs/send_line_message_job_spec.rb
+++ b/spec/jobs/send_line_message_job_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe SendLineMessageJob, type: :job do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
# issue
close #49 

# 内容
・redis + sidekiq + Active Jobの構成で非同期処理を行えるようにした
・ bf99ccb59d0673cd667e4a6983a273680532aaf9 にてLINE送信ジョブの雛形を作成した
・ 597d04dfbcb665399390607bf5077adc3dd89dcd 6f08e53f5650d0ea844b586c3f1f0b535b7e6bdf にて、sidekiqのgemをインストールしてconfigファイルを設定した
・ 5f04e7d5dbe857c3d60b652f4daab1af6f3dbd94 にて、line_messaging_apiコントローラーにLINEのプッシュメッセージを送信するメソッドの雛形を追加し、LINE送信ジョブから呼び出せるようにした
・ d1b9488e7d2e2813a1068be3d32ff60392c98f43 にて、ScheduleクラスにLINEメッセージの文面を生成するインスタンスメソッドを追加し、line_messaging_apiコントローラのプッシュメッセージ送信メソッドを修正した
・ 704a0a61c40c0cb4dca4f51deb3918d30556659e にて、LINE送信ジョブを呼び出すときに、適切な実行時間を設定できるようにした
・ 46718685f41a152aaf33b30548b510ce548ab071 にて、生成されたLINE送信ジョブとScheduleテーブルを紐づけるため、Schedulesテーブルにjob_idカラムを追加した
・ 7177ccb8da6f83f1ac284fad915e0472d031f076 にて、schedulesコントローラーに、スケジュールの作成・更新・削除時に、LINE送信ジョブを追加・削除する機能を追加した

# 確認方法
・development環境でredis、sidekiq、Railsサーバーを起動した状態で、新規作成し、スケジュールの開始日時にLINEメッセージが届くことを確認する

# 確認結果
![ScreenShot 2022-07-21 16 11 47](https://user-images.githubusercontent.com/97581501/180332473-d20333a1-3e71-4b61-a40d-c0def4dcba9c.png)
![AAC080B8-7B49-4E7E-B4DE-8E0E3038A83F](https://user-images.githubusercontent.com/97581501/180332482-8b5dd7ab-d599-47f1-867a-8b7fdc580e35.jpg)

