### PR TITLE
Improve: API関係のコントローラをapp/contorollers/api配下へ移動

### DIFF
--- a/app/controllers/api/line_messaging_api_controller.rb
+++ b/app/controllers/api/line_messaging_api_controller.rb
@@ -1,4 +1,4 @@
-class LineMessagingApiController < ApplicationController
+class Api::LineMessagingApiController < ApplicationController
   require 'line/bot'
   require 'json'
   require 'typhoeus'

--- a/app/jobs/send_line_message_job.rb
+++ b/app/jobs/send_line_message_job.rb
@@ -2,7 +2,7 @@ class SendLineMessageJob < ApplicationJob
   queue_as :default
 
   def perform(*arg)
-    controller = LineMessagingApiController.new
+    controller = Api::LineMessagingApiController.new
     controller.send_push_message_by_schedule_id(arg[0])
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -71,5 +71,5 @@ Rails.application.configure do
   # LINE Messaging APIを開発環境でテストするため
   # ngrokで起動したサーバーを許可する
   # https://www.codegrepper.com/code-examples/ruby/rails+ngrok+blocked+host
-  config.hosts << '6ac5-240b-251-9460-9600-cdf4-8cb5-4d30-31d3.jp.ngrok.io'
+  config.hosts << '4b0d-240b-251-9460-9600-55ea-3c58-d65d-2c0d.jp.ngrok.io'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,4 @@
 Rails.application.routes.draw do
-  get 'settings/index'
-  get 'settings/edit'
-  get 'settings/update'
-  get 'line_users/index'
-  get 'line_users/new'
-  get 'line_users/create'
-  get 'line_users/destroy'
   # トップページ
   root 'static_pages#top'
 
@@ -31,7 +24,7 @@ Rails.application.routes.draw do
 
   # LINEユーザー
   resources :line_users, only: %i(index update destroy)
-  post '/callback', to: 'line_messaging_api#callback'
+  post '/callback', to: 'api/line_messaging_api#callback'
 
   # 通知
   resources :settings, only: %i(index edit update)

--- a/lib/tasks/send_line_message.rake
+++ b/lib/tasks/send_line_message.rake
@@ -1,7 +1,0 @@
-namespace :send_line_message do
-  desc 'LINEメッセージを送信する'
-	task send_test_message: :environment do
-		controller = LineMessagingApiController.new
-    controller.send_broadcast_message('test message')
-	end
-end


### PR DESCRIPTION
# issue
close #52 

# 内容
・ 0785de37f36de7e89316b960607e75be1dae808c にて、`line_messaging_api`コントローラを`app/controllers/api/`配下に移動し、関連する記述を修正した
・ deab6165813c0bec3bf4f84ff3f9d6b8f50b28d8 にて、不要なrakeタスクを削除した