### PR TITLE
Improve: LineMessagingAPI経由のリクエストにおけるCSRF対策を変更

### DIFF
--- a/app/controllers/api/line_messaging_api_controller.rb
+++ b/app/controllers/api/line_messaging_api_controller.rb
@@ -3,8 +3,8 @@ class Api::LineMessagingApiController < ApplicationController
   require 'json'
   require 'typhoeus'
 
-  # 外部からのPOSTリクエストを受けるためにCSRF対策を外す
-  protect_from_forgery except: :callback
+  # 外部からのPOSTリクエストを受けるためにCSRFトークンの検証を制御する
+  protect_from_forgery with: :null_session
   skip_before_action :require_login
 
   def callback

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -71,5 +71,5 @@ Rails.application.configure do
   # LINE Messaging APIを開発環境でテストするため
   # ngrokで起動したサーバーを許可する
   # https://www.codegrepper.com/code-examples/ruby/rails+ngrok+blocked+host
-  config.hosts << '4b0d-240b-251-9460-9600-55ea-3c58-d65d-2c0d.jp.ngrok.io'
+  config.hosts << 'b74b-240b-251-9460-9600-55ea-3c58-d65d-2c0d.jp.ngrok.io'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,7 @@ Rails.application.routes.draw do
 
   # LINEユーザー
   resources :line_users, only: %i(index update destroy)
-  post '/callback', to: 'api/line_messaging_api#callback'
+  post '/api/callback', to: 'api/line_messaging_api#callback'
 
   # 通知
   resources :settings, only: %i(index edit update)


### PR DESCRIPTION
# 内容
・LineMessagingAPI経由のリクエストがあった際に、CSRFトークンの検証自体を無効にしていたが、CSRFトークンの検証が失敗したときは、セッションを無効にするように変更した