### PR TITLE
Change: schedulesテーブルのend_timeにnull制約を追加

### DIFF
--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -4,6 +4,7 @@ class Schedule < ApplicationRecord
   validates :title, presence: true, length: { maximum: 255 }
   validates :body, length: { maximum: 65535 }
   validates :start_time, presence: true
+  validates :end_time, presence: true
   validates :status, presence: true
 
   validate :start_time_cannot_be_in_the_past, on: :create_or_update

--- a/db/migrate/20220723100832_add_null_constrait_to_end_time.rb
+++ b/db/migrate/20220723100832_add_null_constrait_to_end_time.rb
@@ -1,0 +1,5 @@
+class AddNullConstraitToEndTime < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :schedules, :end_time, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_07_22_051504) do
+ActiveRecord::Schema[7.0].define(version: 2022_07_23_100832) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -30,7 +30,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_22_051504) do
     t.string "title", limit: 255, null: false
     t.string "body", limit: 65535
     t.datetime "start_time", precision: nil, null: false
-    t.datetime "end_time", precision: nil
+    t.datetime "end_time", precision: nil, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "job_id", default: "", null: false


### PR DESCRIPTION
# 内容
・カレンダー形式でスケジュールを表示する際に必要となるため、schedulesテーブルのend_timeにnull制約を追加した