### PR TITLE
Change&Add: userテーブルとline_usersテーブルを多：多の関係に変更

### DIFF
--- a/app/controllers/api/line_login_api_controller.rb
+++ b/app/controllers/api/line_login_api_controller.rb
@@ -50,20 +50,18 @@ class Api::LineLoginApiController < ApplicationController
 
       user = User.find(session[:app_user_id])
       line_user_params = get_line_user_params(params[:code])
-      line_user = user.line_users.new(line_user_params)
+      line_user = LineUser.find_or_initialize_by(line_user_id: line_user_params[:line_user_id])
+      line_user.assign_attributes(line_user_params)
 
-      if line_user.save
-        # line_userが妥当なデータだったとき
+      if line_user.save && UserLineUserRelationship.find_or_create_by(user: user, line_user: line_user)
         reset_session_before_redirect(session[:self])
         flash[:success] = 'トリコミのLINEユーザーに追加されました'
-      else
-        # line_userが不正なデータだったとき
+      else # line_userが不正か、relationが不正だったとき
         reset_session_before_redirect(session[:self])
         flash[:error] = 'エラーが起きました'
       end
 
-    else
-      # LINEログインの通信に失敗しているとき
+    else # LINEログインの通信に失敗しているとき
       reset_session_before_redirect(session[:self])
       flash[:error] = 'エラーが起きました'
     end

--- a/app/models/line_user.rb
+++ b/app/models/line_user.rb
@@ -2,7 +2,7 @@ class LineUser < ApplicationRecord
   has_many :user_line_user_relationships, dependent: :destroy
   has_many :users, through: :user_line_user_relationships
 
-  validates :line_user_id, presence: true, uniqueness: { scope: :user }
+  validates :line_user_id, presence: true, uniqueness: true
   validates :display_name, presence: true
   validates :status, presence: true
 

--- a/app/models/line_user.rb
+++ b/app/models/line_user.rb
@@ -1,5 +1,6 @@
 class LineUser < ApplicationRecord
-  belongs_to :user
+  has_many :user_line_user_relationships, dependent: :destroy
+  has_many :users, through: :user_line_user_relationships
 
   validates :line_user_id, presence: true, uniqueness: { scope: :user }
   validates :display_name, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,8 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
   has_many :schedules, dependent: :destroy
-  has_many :line_users, dependent: :destroy
+  has_many :user_line_user_relationships, dependent: :destroy
+  has_many :line_users, through: :user_line_user_relationships
   has_one :setting, dependent: :destroy
   has_many :link_tokens
 

--- a/app/models/user_line_user_relationship.rb
+++ b/app/models/user_line_user_relationship.rb
@@ -1,0 +1,4 @@
+class UserLineUserRelationship < ApplicationRecord
+  belongs_to :user
+  belongs_to :line_user
+end

--- a/app/views/line_users/index.html.slim
+++ b/app/views/line_users/index.html.slim
@@ -7,7 +7,7 @@
       h2.text-4xl.font-bold.py-6
         | LINEユーザー新規登録
       .py-2
-        .collapse.collapse-plus.border.border-base-300.bg-base-100.rounded-box[tabindex="0"]
+        .collapse.collapse-open.border.border-base-300.bg-base-100.rounded-box[tabindex="0"]
           .collapse-title.text-xl.font-medium
             | 自分のLINEアカウントを登録したいとき
           .collapse-content
@@ -20,7 +20,7 @@
             p
             | ②登録済LINEユーザー一覧に自分のLINEアカウントが表示されていればOK！
       .py-2
-        .collapse.collapse-plus.border.border-base-300.bg-base-100.rounded-box[tabindex="0"]
+        .collapse.collapse-open.border.border-base-300.bg-base-100.rounded-box[tabindex="0"]
           .collapse-title.text-xl.font-medium
             | 他人のLINEアカウントを登録したいとき
           .collapse-content

--- a/db/migrate/20220717104330_create_schedules.rb
+++ b/db/migrate/20220717104330_create_schedules.rb
@@ -5,7 +5,7 @@ class CreateSchedules < ActiveRecord::Migration[7.0]
       t.string :title, null: false, limit: 255
       t.string :body, limit: 65535
       t.timestamp :start_time, null: false
-      t.timestamp :end_time
+      t.timestamp :end_time, null: false
 
       t.timestamps
     end

--- a/db/migrate/20220718225639_create_line_users.rb
+++ b/db/migrate/20220718225639_create_line_users.rb
@@ -1,7 +1,6 @@
 class CreateLineUsers < ActiveRecord::Migration[7.0]
   def change
     create_table :line_users do |t|
-      t.references :user, null: false, foreign_key: true
       t.string :line_user_id, null: false
       t.string :display_name, null: false
       t.string :picture_url

--- a/db/migrate/20220719105728_add_status_to_line_users.rb
+++ b/db/migrate/20220719105728_add_status_to_line_users.rb
@@ -1,4 +1,4 @@
-class AddStatusAndOtpToLineUsers < ActiveRecord::Migration[7.0]
+class AddStatusToLineUsers < ActiveRecord::Migration[7.0]
   def change
     add_column :line_users, :status, :integer, null: false, default: 0
   end

--- a/db/migrate/20220723100832_add_null_constrait_to_end_time.rb
+++ b/db/migrate/20220723100832_add_null_constrait_to_end_time.rb
@@ -1,5 +1,0 @@
-class AddNullConstraitToEndTime < ActiveRecord::Migration[7.0]
-  def change
-    change_column_null :schedules, :end_time, false
-  end
-end

--- a/db/migrate/20220727000934_create_user_line_user_relationships.rb
+++ b/db/migrate/20220727000934_create_user_line_user_relationships.rb
@@ -1,0 +1,9 @@
+class CreateUserLineUserRelationships < ActiveRecord::Migration[7.0]
+  def change
+    create_table :user_line_user_relationships do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :line_user, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220727005353_add_uniqueness_constraint_to_line_users.rb
+++ b/db/migrate/20220727005353_add_uniqueness_constraint_to_line_users.rb
@@ -1,0 +1,5 @@
+class AddUniquenessConstraintToLineUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_index :line_users, :line_user_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,19 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_07_26_075117) do
+ActiveRecord::Schema[7.0].define(version: 2022_07_27_000934) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "line_users", force: :cascade do |t|
-    t.bigint "user_id", null: false
     t.string "line_user_id", null: false
     t.string "display_name", null: false
     t.string "picture_url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "status", default: 0, null: false
-    t.index ["user_id"], name: "index_line_users_on_user_id"
   end
 
   create_table "link_tokens", force: :cascade do |t|
@@ -56,6 +54,15 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_26_075117) do
     t.index ["user_id"], name: "index_settings_on_user_id", unique: true
   end
 
+  create_table "user_line_user_relationships", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "line_user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["line_user_id"], name: "index_user_line_user_relationships_on_line_user_id"
+    t.index ["user_id"], name: "index_user_line_user_relationships_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", null: false
     t.string "crypted_password"
@@ -65,8 +72,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_26_075117) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
-  add_foreign_key "line_users", "users"
   add_foreign_key "link_tokens", "users"
   add_foreign_key "schedules", "users"
   add_foreign_key "settings", "users"
+  add_foreign_key "user_line_user_relationships", "line_users"
+  add_foreign_key "user_line_user_relationships", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_07_27_000934) do
+ActiveRecord::Schema[7.0].define(version: 2022_07_27_005353) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -21,6 +21,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_27_000934) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "status", default: 0, null: false
+    t.index ["line_user_id"], name: "index_line_users_on_line_user_id", unique: true
   end
 
   create_table "link_tokens", force: :cascade do |t|

--- a/spec/factories/user_line_user_relationships.rb
+++ b/spec/factories/user_line_user_relationships.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :user_line_user_relationship do
+    
+  end
+end

--- a/spec/models/user_line_user_relationship_spec.rb
+++ b/spec/models/user_line_user_relationship_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe UserLineUserRelationship, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
# issue
close #68 

# 内容
・ 09c879cc5368a9bbb478958d25253a14740d0bf4 ec27a724ecac8ee54ffae05ad6ce58aa287179ae  にてusersテーブルとline_usersテーブルの中間テーブル、user_line_user_relationshipsテーブルを追加
・ d2454fb281b93a75d5ec710f51d30edf760096e5 にて、line_usersテーブルのline_user_isにユニーク制約を追加した
・ e7027bc03b780538806677dc63713a584afab258 にて、テーブル変更の影響をうけて、LINEログイン処理を修正した