### PR TITLE
Change: link_tokenのダイジェストをデータベースに保存

### DIFF
--- a/app/controllers/line_users_controller.rb
+++ b/app/controllers/line_users_controller.rb
@@ -2,7 +2,7 @@ class LineUsersController < ApplicationController
 
   def index
     @line_users = current_user.line_users
-    @login_url = create_login_url(current_user)
+    @login_url = LinkToken.create_line_login_url(root_url, current_user)
   end
 
   def update
@@ -25,14 +25,4 @@ class LineUsersController < ApplicationController
     @line_user.destroy!
     redirect_to line_users_path, success: t('.success')
   end
-
-  private
-
-  def create_login_url(user)
-    token = SecureRandom.urlsafe_base64
-    user.link_tokens.create!(token: token)
-    login_url = root_url + 'api/' + token + '/login'
-    login_url
-  end
-
 end

--- a/app/models/link_token.rb
+++ b/app/models/link_token.rb
@@ -2,7 +2,19 @@ class LinkToken < ApplicationRecord
   belongs_to :user
   validates :token_digest, presence: true
 
-  def not_expired?
-    created_at > 1.days.ago.in_time_zone
+  def self.create_line_login_url(root_url, user)
+    token = SecureRandom.urlsafe_base64
+    user.link_tokens.create!(token_digest: Digest::MD5.hexdigest(token))
+    line_login_url = root_url + 'api/' + token + "/login?app_user_id=#{user.id.to_s}"
+    line_login_url
+  end
+
+  def self.valid?(user_id, token)
+    link_token = LinkToken.find_by(user_id: user_id, token_digest: Digest::MD5.hexdigest(token))
+    if link_token.present? && link_token.created_at > 1.days.ago.in_time_zone
+      true
+    else
+      false
+    end
   end
 end

--- a/app/models/link_token.rb
+++ b/app/models/link_token.rb
@@ -1,6 +1,6 @@
 class LinkToken < ApplicationRecord
   belongs_to :user
-  validates :token, presence: true, uniqueness: true
+  validates :token_digest, presence: true
 
   def not_expired?
     created_at > 1.days.ago.in_time_zone

--- a/app/views/line_users/index.html.slim
+++ b/app/views/line_users/index.html.slim
@@ -16,7 +16,7 @@
             br
             | 　続けて「トリコミ」LINE公式アカウントを友だち登録！
             .py-2
-              = link_to 'LINEでログイン', @login_url + '?self=true', class: 'button btn btn-primary'
+              = link_to 'LINEでログイン', @login_url + '&self=true', class: 'button btn btn-primary'
             p
             | ②登録済LINEユーザー一覧に自分のLINEアカウントが表示されていればOK！
       .py-2
@@ -27,7 +27,7 @@
             p
             | ①下記のボタンからLINEログインURLを発行して、追加したいLINEユーザーに送信
             .py-2
-              = link_to 'ログインURLを送信', "https://line.me/R/share?text=%E3%80%8C%E3%83%88%E3%83%AA%E3%82%B3%E3%83%9F%E3%80%8D%E3%81%AB%E3%83%AD%E3%82%B0%E3%82%A4%E3%83%B3%EF%BC%81%0D%0A%EF%BC%88URL%E3%81%AE%E6%9C%89%E5%8A%B9%E6%9C%9F%E9%99%90%EF%BC%9A24%E6%99%82%E9%96%93%EF%BC%89%0D%0A%0D%0A#{@login_url}%3Fself%3Dfalse", class: 'button btn btn-primary'
+              = link_to 'ログインURLを送信', "https://line.me/R/share?text=%E3%80%8C%E3%83%88%E3%83%AA%E3%82%B3%E3%83%9F%E3%80%8D%E3%81%AB%E3%83%AD%E3%82%B0%E3%82%A4%E3%83%B3%EF%BC%81%0D%0A%EF%BC%88URL%E3%81%AE%E6%9C%89%E5%8A%B9%E6%9C%9F%E9%99%90%EF%BC%9A24%E6%99%82%E9%96%93%EF%BC%89%0D%0A%0D%0A#{CGI.escape(@login_url+'&self=false')}", class: 'button btn btn-primary'
             p
             | ②（URLを受け取ったLINEユーザー）①のURLからログイン
             br

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -71,5 +71,5 @@ Rails.application.configure do
   # LINE Messaging APIを開発環境でテストするため
   # ngrokで起動したサーバーを許可する
   # https://www.codegrepper.com/code-examples/ruby/rails+ngrok+blocked+host
-  config.hosts << '82f0-240b-251-9460-9600-24f5-87bb-9722-3ba6.jp.ngrok.io'
+  config.hosts << 'f155-240b-251-9460-9600-10f0-be34-3ae0-852.jp.ngrok.io'
 end

--- a/db/migrate/20220728015618_rename_token_to_token_digest.rb
+++ b/db/migrate/20220728015618_rename_token_to_token_digest.rb
@@ -1,0 +1,5 @@
+class RenameTokenToTokenDigest < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :link_tokens, :token, :token_digest
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_07_27_005353) do
+ActiveRecord::Schema[7.0].define(version: 2022_07_28_015618) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -26,7 +26,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_27_005353) do
 
   create_table "link_tokens", force: :cascade do |t|
     t.bigint "user_id", null: false
-    t.string "token", null: false
+    t.string "token_digest", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_link_tokens_on_user_id"


### PR DESCRIPTION
# 内容
link_tokensテーブルに、トークンそのものではなく、ダイジェストを保存するようにした
・ a700598edb4d2ea88839ffc833855b62e3f48ac1 にて、link_tokensテーブルのカラム名を変更した
・ f7b8937e4d7535e74904c71cc6064d85a48133c9 にて、トークンのダイジェストを保存するようにしたことによって影響を受ける、LINEログインの処理の部分を修正した