### PR TITLE
Fix: 通知メッセージ設定時にLINE送信ジョブも更新するように修正

### DIFF
--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,4 +1,5 @@
 class SettingsController < ApplicationController
+  require 'sidekiq/api'
   before_action :set_setting
 
   def show
@@ -9,7 +10,20 @@ class SettingsController < ApplicationController
   end
 
   def update
+    notification_time_before = @setting.notification_time
     if @setting.update(setting_params)
+      if notification_time_before != @setting.notification_time
+        current_user.schedules.to_be_sent.each do |schedule|
+          # Sidekiqに登録されているLINEメッセージの送信ジョブを削除する
+          ss = Sidekiq::ScheduledSet.new
+          jobs = ss.select { |job| job.args[0]['job_id'] == schedule.job_id }
+          jobs.each(&:delete)
+
+          # 新しくジョブを登録する
+          job = SendLineMessageJob.set(wait_until: schedule.start_time - @setting.notification_time*60).perform_later(schedule.id)
+          schedule.update!(job_id: job.job_id)
+        end
+      end
       redirect_to session[:previous_url] ||= dashboards_path, success: t('.success')
     else
       flash.now[:error] = t('.fail')


### PR DESCRIPTION
# 内容
・settings_controllerにおいて、settingが更新された時に、そのユーザーのスケジュールのLINE送信ジョブも更新するように修正した