### PR TITLE
Improve: LineLoginApiコントローラのCSRF対策の修正

### DIFF
--- a/app/controllers/api/line_login_api_controller.rb
+++ b/app/controllers/api/line_login_api_controller.rb
@@ -5,7 +5,8 @@ class Api::LineLoginApiController < ApplicationController
 
   skip_before_action :require_login, only: %i(login callback)
 
-  # sessionを有効にするためにCSRF対策を外す（あとで検討）
+  # WebアプリとLINEプラットフォーム間でのCSRF対策は自前で行うため
+  # RailsデフォルトのCSRF対策メソッドは無効化する
   protect_from_forgery except: %i(login callback)
 
   def login


### PR DESCRIPTION
# issue
close #43 

# 内容
`LineLoginApi`コントローラでは、自前でCSRF防止用のトークンを発行して、それをLINEプラットフォームとの通信時に検証しているため、RailsデフォルトのCSRF防止用メソッド`protect_from_forgery`はオフのままにしておく。
・ 527ad4cca43e3a46a9971ea8a4ed23dac793f18a にて、上記を反映させたコメントを追加。

# 参考
https://developers.line.biz/ja/docs/line-login/integrate-line-login/#making-an-authorization-request