### PR TITLE
Add: 古いLinkTokenを定期的に削除するジョブを追加

### DIFF
--- a/app/jobs/delete_old_link_tokens_job.rb
+++ b/app/jobs/delete_old_link_tokens_job.rb
@@ -1,0 +1,7 @@
+class DeleteOldLinkTokensJob < ApplicationJob
+  def perform
+    LinkToken.where("created_at < ?", 1.days.ago.in_time_zone).each do |old_link_token|
+      old_link_token.destroy!
+    end
+  end
+end

--- a/app/models/link_token.rb
+++ b/app/models/link_token.rb
@@ -8,13 +8,4 @@ class LinkToken < ApplicationRecord
     line_login_url = root_url + 'api/line_login/' + token + "/login?app_user_id=#{user.id.to_s}"
     line_login_url
   end
-
-  def self.valid?(user_id, token)
-    link_token = LinkToken.find_by(user_id: user_id, token_digest: Digest::MD5.hexdigest(token))
-    if link_token.present? && link_token.created_at > 1.days.ago.in_time_zone
-      true
-    else
-      false
-    end
-  end
 end

--- a/app/services/line_login/login_url_validate_service.rb
+++ b/app/services/line_login/login_url_validate_service.rb
@@ -1,14 +1,14 @@
 class LineLogin::LoginUrlValidateService
   def initialize(params)
-    @user = User.find_by(id: params[:app_user_id].to_i)
-    @link_token = params[:link_token]
+    @user = User.find_by(id: params[:app_user_id])
+    @link_token = LinkToken.find_by(user_id: params[:app_user_id], token_digest: Digest::MD5.hexdigest(params[:link_token]))
     @self = params[:self]
   end
 
   def call
-    # @userが存在し、@link_tokenが正しく、@selfが正しいフォーマットの場合にLINEログイン処理へ移る
+    # @user、@link_tokenが存在し、@selfが正しいフォーマットの場合にLINEログイン処理へ移る
     # @selfは、アプリユーザーが自分のLINEアカウントを登録しようとしているときにtrue
     # アプリユーザーが自分でないLINEユーザーに登録してもらおうとしているときにfalse
-    @user && LinkToken.valid?(@user.id, @link_token) && ( @self == 'true' || @self == 'false' )
+    @user && @link_token && ( @self == 'true' || @self == 'false' )
   end
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,3 +3,6 @@
   delete_old_schedules:
     cron: '0 0 0 * * *'
     class: DeleteOldSchedulesJob
+  delete_old_link_tokens:
+    cron: '0 0 0 * * *'
+    class: DeleteOldLinkTokensJob


### PR DESCRIPTION
# issue
close #67 

# 内容
・1日以上前に作成されたLinkTokenを削除するジョブを毎日0時に実行するようにした
・上記のジョブの追加により、LINEログイン時のLinkTokenの作成日時のチェックが不要になったため、該当部分を削除した