### PR TITLE
Add: Googleカレンダーからスケジュールを自動で取得する機能の追加

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -22,6 +22,6 @@
   border: none !important;
   --green-500: #529B03 !important;
   --green-600: #529B03 !important;
-  --gray-500: #191A3E !important;
-  --gray-600: #191A3E !important;
+  --indigo-500: #E6E6E6 !important;
+  --indigo-600: #E6E6E6 !important;
 }

--- a/app/controllers/api/google_calendar_api_controller.rb
+++ b/app/controllers/api/google_calendar_api_controller.rb
@@ -28,12 +28,12 @@ class Api::GoogleCalendarApiController < ApplicationController
       google_calendar_token.assign_attributes(access_token: @auth_client.access_token, refresh_token: @auth_client.refresh_token, expires_at: @auth_client.expires_at, google_calendar_id: service.get_calendar('primary').id)
 
       if google_calendar_token.save
-        redirect_back_or_to dashboards_path, success: t('.success')
+        redirect_back_or_to schedules_path, success: t('.success')
       else
-        redirect_back_or_to dashboards_path, error: t('.fail')
+        redirect_back_or_to google_calendar_setting_path, error: t('.fail')
       end
     else
-      redirect_back_or_to dashboards_path, error: t('.fail')
+      redirect_back_or_to google_calendar_setting_path, error: t('.fail')
     end
   end
 
@@ -41,9 +41,9 @@ class Api::GoogleCalendarApiController < ApplicationController
     if current_user.google_calendar_token.present?
       set_service = GoogleCalendar::ScheduleSetService.new(current_user, @auth_client)
       set_service.call
-      redirect_to dashboards_path, success: t('.success')
+      redirect_to schedules_path, success: t('.success')
     else
-      redirect_to dashboards_path, error: t('.fail')
+      redirect_to google_calendar_setting_path, error: t('.fail')
     end
   end
 

--- a/app/controllers/google_calendar_settings_controller.rb
+++ b/app/controllers/google_calendar_settings_controller.rb
@@ -1,29 +1,29 @@
 class GoogleCalendarSettingsController < ApplicationController
-  before_action :set_google_calendar_setting
-  
+#   before_action :set_google_calendar_setting
+
   def show
   end
-  
-  def edit
-    session[:previous_url] = request.referer
-  end
-  
-  def update
-    if @google_calendar_setting.update(google_calendar_setting_params)
-      redirect_to session[:previous_url] ||= dashboards_path, success: t('.success')
-    else
-      flash.now[:error] = t('.fail')
-      render :edit, status: :unprocessable_entity
-    end
-  end
-  
-  private
-  
-  def set_google_calendar_setting
-    @google_calendar_setting = current_user.google_calendar_setting
-  end
-  
-  def google_calendar_setting_params
-    params.require(:google_calendar_setting).permit(:monday, :tuesday, :wednesday, :thursday, :friday, :saturday, :sunday, :start_time_hour, :start_time_min, :end_time_hour, :end_time_min)
-  end
+
+#   def edit
+#     session[:previous_url] = request.referer
+#   end
+#  
+#  def update
+#     if @google_calendar_setting.update(google_calendar_setting_params)
+#       redirect_to session[:previous_url] ||= dashboards_path, success: t('.success')
+#     else
+#       flash.now[:error] = t('.fail')
+#       render :edit, status: :unprocessable_entity
+#     end
+#   end
+# 
+#   private
+# 
+#   def set_google_calendar_setting
+#     @google_calendar_setting = current_user.google_calendar_setting
+#   end
+# 
+#   def google_calendar_setting_params
+#     params.require(:google_calendar_setting).permit(:monday, :tuesday, :wednesday, :thursday, :friday, :saturday, :sunday, :start_time_hour, :start_time_min, :end_time_hour, :end_time_min)
+#   end
 end

--- a/app/controllers/google_calendar_tokens_controller.rb
+++ b/app/controllers/google_calendar_tokens_controller.rb
@@ -2,6 +2,6 @@ class GoogleCalendarTokensController < ApplicationController
   def destroy
     google_calendar_token = current_user.google_calendar_token
     google_calendar_token.destroy!
-    redirect_back_or_to dashboards_path, success: t('.success')
+    redirect_back_or_to google_calendar_setting_path, success: t('.success')
   end
 end

--- a/app/controllers/line_users_controller.rb
+++ b/app/controllers/line_users_controller.rb
@@ -5,21 +5,6 @@ class LineUsersController < ApplicationController
     @login_url = LinkToken.create_line_login_url(root_url, current_user)
   end
 
-  def update
-    @line_user = current_user.line_users.find(params[:id])
-    if params[:notification] == 'on'
-      @line_user.assign_attributes(status: :notification_on)
-    else
-      @line_user.assign_attributes(status: :notification_off)
-    end
-    if @line_user.save
-      redirect_to line_users_path, success: t('.success')
-    else
-      flash.now[:error] = t('.fail')
-      render :index, status: :unprocessable_entity
-    end
-  end
-
   def destroy
     @line_user = current_user.line_users.find(params[:id])
     @line_user.destroy!

--- a/app/javascript/dashboards.js
+++ b/app/javascript/dashboards.js
@@ -23,7 +23,7 @@ if(document.querySelector('#calendar')){
           this.attrs.push({
             key: `schedule-${schedule_id.toString()}`,
             bar: {
-              color: schedule['status'] === 'to_be_sent' ? 'green' : 'gray'
+              color: schedule['status'] === 'to_be_sent' ? 'green' : 'indigo'
             },
             dates: start_time_date,
             popover: {

--- a/app/javascript/schedules.js
+++ b/app/javascript/schedules.js
@@ -40,6 +40,12 @@ if(document.querySelector('#schedule-list')){
       clickAccordion(schedule_id){
         this.$set(this.accordionFlags, schedule_id, !this.accordionFlags[schedule_id]);
         this.flag = !this.flag;
+      },
+      confirmationDialog(event){
+        const result = confirm('本当に削除しますか？');
+        if(!result){
+          event.preventDefault();
+        }
       }
     }
   });

--- a/app/javascript/schedules.js
+++ b/app/javascript/schedules.js
@@ -11,6 +11,7 @@ if(document.querySelector('#schedule-list')){
       return{
         toBeSent: true,
         sent: false,
+        draft: false,
         accordionFlags: {},
         flag: false
       };
@@ -19,10 +20,17 @@ if(document.querySelector('#schedule-list')){
       toBeSentTabClick(){
         this.toBeSent = true;
         this.sent = false;
+        this.draft = false;
       },
       sentTabClick(){
         this.toBeSent = false;
         this.sent = true;
+        this.draft = false;
+      },
+      draftTabClick(){
+        this.toBeSent = false;
+        this.sent = false;
+        this.draft = true;
       },
       setAccordionFlags(schedules_json){
         for(const schedule_json of schedules_json){

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,7 +1,10 @@
 class ApplicationJob < ActiveJob::Base
-  # Automatically retry jobs that encountered a deadlock
-  # retry_on ActiveRecord::Deadlocked
+  # Active JobでURLヘルパーを使えるようにする
+  include Rails.application.routes.url_helpers
 
-  # Most jobs are safe to ignore if the underlying records are no longer available
-  # discard_on ActiveJob::DeserializationError
+  protected
+
+  def default_url_options
+    Rails.application.config.action_controller.default_url_options
+  end
 end

--- a/app/jobs/delete_draft_schedules_job.rb
+++ b/app/jobs/delete_draft_schedules_job.rb
@@ -1,0 +1,11 @@
+class DeleteDraftSchedulesJob < ApplicationJob
+
+  queue_as :default
+
+  def perform
+    Schedule.draft.where("end_time < ?", Time.zone.now).each do |draft_schedule|
+      draft_schedule.destroy!
+    end
+  end
+
+end

--- a/app/jobs/update_schedules_from_google_calendar_job.rb
+++ b/app/jobs/update_schedules_from_google_calendar_job.rb
@@ -1,0 +1,40 @@
+class UpdateSchedulesFromGoogleCalendarJob < ApplicationJob
+  require 'google/apis/calendar_v3'
+  require 'google/api_client/client_secrets'
+
+  queue_as :default
+
+  def perform
+    auth_client = get_auth_client
+    User.all.each do |user|
+      if user.google_calendar_token.present?
+        set_service = GoogleCalendar::ScheduleSetService.new(user, auth_client)
+        set_service.call
+      end
+    end
+  end
+
+  private
+
+  def get_auth_client
+    client_secrets = Google::APIClient::ClientSecrets.new({
+      "web":{
+        "client_id":ENV['GOOGLE_CALENDAR_CLIENT_ID'],
+        "auth_uri":"https://accounts.google.com/o/oauth2/auth",
+        "token_uri":"https://oauth2.googleapis.com/token",
+        "client_secret":ENV['GOOGLE_CALENDAR_CLIENT_SECRET'],
+        "redirect_uris":[api_google_calendar_callback_url]
+      }
+    })
+    auth_client = client_secrets.to_authorization
+    auth_client.update!(
+      scope: 'https://www.googleapis.com/auth/calendar.readonly',
+      additional_parameters: {
+        access_type: 'offline',
+        prompt: 'consent',
+        session: false
+      }
+    )
+    auth_client
+  end
+end

--- a/app/models/line_user.rb
+++ b/app/models/line_user.rb
@@ -4,7 +4,4 @@ class LineUser < ApplicationRecord
 
   validates :line_user_id, presence: true, uniqueness: true
   validates :display_name, presence: true
-  validates :status, presence: true
-
-  enum status: { notification_on: 0, notification_off: 1 }
 end

--- a/app/views/dashboards/index.html.slim
+++ b/app/views/dashboards/index.html.slim
@@ -50,7 +50,7 @@
             - current_user.line_users.each_with_index do |line_user, index|
               - if index != 0
                 hr
-              .flex
+              .flex.items-center
                 .flex-none.pr-4
                   .avatar
                     .w-12.rounded-full
@@ -58,8 +58,6 @@
                 .flex-none
                   p
                     = line_user.display_name
-                    br
-                    = line_user.status_i18n
           - else
             p
               | LINEユーザーがいません

--- a/app/views/google_calendar_settings/edit.html.slim
+++ b/app/views/google_calendar_settings/edit.html.slim
@@ -1,5 +1,5 @@
-- content_for(:title, t('.title'))
-.hero.min-h-screen.bg-base-200
+/- content_for(:title, t('.title'))
+/.hero.min-h-screen.bg-base-200
   .w-screen.px-4.my-12.max-w-sm.sm:max-w-lg
     - if @google_calendar_setting.errors.any?
       ul.text-error-content.mb-4

--- a/app/views/google_calendar_settings/show.html.slim
+++ b/app/views/google_calendar_settings/show.html.slim
@@ -4,7 +4,7 @@
     h1.text-3xl.font-bold.mb-4
       = t('.title')
     p.mb-3
-      | Googleカレンダーと連携して、通知するスケジュールを自動で取得します。
+      | Googleカレンダーと連携して、スケジュールを自動で取得します（毎日0時に更新）。
       | 連携開始時の注意事項は
       = link_to 'こちら', faq_path, class: 'link'
       | 。
@@ -16,15 +16,17 @@
           p
             = current_user.google_calendar_token.google_calendar_id
           .card-actions.justify-end
-            = link_to '手動更新', api_google_calendar_update_path, class: 'button btn btn-info'
-          .card-actions.justify-end
-            = button_to '連携解除', google_calendar_token_path(current_user.google_calendar_token), method: :delete, class: 'button btn btn-error'
+            .flex
+              .flex-none.pr-2
+                = link_to '手動更新', api_google_calendar_update_path, class: 'button btn btn-info'
+              .flex-none
+                = button_to '連携解除', google_calendar_token_path(current_user.google_calendar_token), method: :delete, class: 'button btn btn-error'
         - else
           p
             | カレンダーが連携されていません
           .card-actions.justify-end
             = link_to '連携する', api_google_calendar_authorize_path, class: 'button btn btn-primary'
-    - if current_user.google_calendar_token.present?
+    /- if current_user.google_calendar_token.present?
       .card.shadow.bg-base-100
         .card-body
           h2.card-title

--- a/app/views/line_users/index.html.slim
+++ b/app/views/line_users/index.html.slim
@@ -16,17 +16,8 @@
                 = image_tag line_user.picture_url || 'noimage.png'
             h2.card-title
               = line_user.display_name
-            p
-              = line_user.status_i18n
-            .card-actions.justify-end
-              .flex
-                .flex-none.pr-2
-                  - if line_user.notification_on?
-                    = button_to '通知オフ', line_user_path(line_user, notification: 'off'), method: :patch, class: 'button btn btn-info'
-                  - else 
-                    = button_to '通知オン', line_user_path(line_user, notification: 'on'), method: :patch, class: 'button btn btn-info'
-                .flex-none[data-turbo="true"]
-                  = button_to '削除', line_user_path(line_user), method: :delete, form: { data: { turbo_confirm: "本当に削除しますか？" } }, class: 'button btn btn-error'
+            .card-actions.justify-end[data-turbo="true"]
+              = button_to '削除', line_user_path(line_user), method: :delete, form: { data: { turbo_confirm: "本当に削除しますか？" } }, class: 'button btn btn-error'
         - else
           p
             = t('.no_result')

--- a/app/views/schedules/_form.html.slim
+++ b/app/views/schedules/_form.html.slim
@@ -22,5 +22,10 @@
           span.label-text
             = Schedule.human_attribute_name('end_time') + '（必須）'
         = f.datetime_field :end_time, class: 'input input-bordered'
+      .form-control
+        label.label
+          span.label-text
+            = Schedule.human_attribute_name('status') + '（必須）'
+        = f.select :status, Schedule.statuses_i18n.invert.slice("下書き", "送信予約"), {}, class: 'input input-bordered'
       .form-control.mt-6
         = f.submit class: 'btn btn-primary'

--- a/app/views/schedules/_schedule.html.slim
+++ b/app/views/schedules/_schedule.html.slim
@@ -30,5 +30,5 @@
           - if schedule.default?
             .flex-none.pr-2
               = link_to '編集', edit_schedule_path(schedule), class: 'btn btn-info'
-            .flex-none[data-turbo="true"]
-              = button_to '削除', schedule_path(schedule), method: :delete, form: { data: { turbo_confirm: "本当に削除しますか？" } }, class: 'btn btn-error'
+            .flex-none
+              = button_to '削除', schedule_path(schedule), method: :delete, class: 'btn btn-error'

--- a/app/views/schedules/_schedule.html.slim
+++ b/app/views/schedules/_schedule.html.slim
@@ -25,5 +25,5 @@
           - if schedule.default?
             .flex-none.pr-2
               = link_to '編集', edit_schedule_path(schedule), class: 'button btn btn-info'
-          .flex-none.pr-2[data-turbo="true"]
+          .flex-none[data-turbo="true"]
             = button_to '削除', schedule_path(schedule), method: :delete, form: { data: { turbo_confirm: "本当に削除しますか？" } }, class: 'button btn btn-error'

--- a/app/views/schedules/_schedule.html.slim
+++ b/app/views/schedules/_schedule.html.slim
@@ -20,10 +20,15 @@
       svg.w-4.transform[fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 16 10" aria-hidden="true" :class="{'rotate-180': accordionFlags[#{schedule.id.to_s}], 'rotate-0': !accordionFlags[#{schedule.id.to_s}]}"]
         path[d="M15 1.2l-7 7-7-7" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"]
     .card-actions.justify-end
-      - if schedule.to_be_sent? 
+      - if schedule.to_be_sent? || schedule.draft?
         .flex
+          .flex-none.pr-2
+            - if schedule.to_be_sent?
+              = button_to '送信予約取消', schedule_path(schedule, status: 'draft'), method: :patch, class: 'btn btn-primary'
+            - else
+              = button_to '送信予約', schedule_path(schedule, status: 'to_be_sent'), method: :patch, class: 'btn btn-primary'
           - if schedule.default?
             .flex-none.pr-2
-              = link_to '編集', edit_schedule_path(schedule), class: 'button btn btn-info'
-          .flex-none[data-turbo="true"]
-            = button_to '削除', schedule_path(schedule), method: :delete, form: { data: { turbo_confirm: "本当に削除しますか？" } }, class: 'button btn btn-error'
+              = link_to '編集', edit_schedule_path(schedule), class: 'btn btn-info'
+            .flex-none[data-turbo="true"]
+              = button_to '削除', schedule_path(schedule), method: :delete, form: { data: { turbo_confirm: "本当に削除しますか？" } }, class: 'btn btn-error'

--- a/app/views/schedules/index.html.slim
+++ b/app/views/schedules/index.html.slim
@@ -16,6 +16,8 @@
       .tabs.mb-3
         a.tab.tab-bordered.tab-lg(@click="toBeSentTabClick" :class="{'tab-active': toBeSent }")
           = Schedule.statuses_i18n["to_be_sent"]
+        a.tab.tab-bordered.tab-lg(@click="draftTabClick" :class="{'tab-active': draft }")
+          = Schedule.statuses_i18n["draft"]
         a.tab.tab-bordered.tab-lg(@click="sentTabClick" :class="{'tab-active': sent }")
           = Schedule.statuses_i18n["sent"]
       .[v-if="toBeSent"]
@@ -24,11 +26,20 @@
         - else
           p.mb-3
             = t('.no_result')
+      .[v-else-if="draft"]
+        - if @schedules.draft.present?
+          = render @schedules.draft
+        - else
+          p.mb-3
+              = t('.no_result')
       .[v-else]
         - if @schedules.sent.present?
           = render @schedules.sent
         - else
           p.mb-3
               = t('.no_result')
+
     p
       | ※スケジュールは1か月で削除されます。
+      br
+      | ※下書き状態のスケジュールは送信されません。

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -15,7 +15,7 @@
         .card-actions.justify-end
           = link_to 'プロフィール画像の変更（準備中）', '#', class: 'button btn btn-ghost btn-active'
         .card-actions.justify-end
-          = link_to 'メールアドレス・パスワードの変更（準備中）', '#', class: 'button btn btn-ghost btn-active'
+          = link_to 'ユーザー情報の変更（準備中）', '#', class: 'button btn btn-ghost btn-active'
     .card.bg-base-100.shadow
       .card-body
         h2.card-title

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -85,4 +85,7 @@ Rails.application.configure do
     password: ENV['GMAIL_APP_PASSWORD'],  #アプリパスワード
     authentication: :login
   }
+
+  # Active JobでもURLヘルパーを使うために、default_urlを設定
+  config.action_controller.default_url_options = {  host: 'localhost', port: 3000 }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -102,4 +102,7 @@ Rails.application.configure do
     password: ENV['GMAIL_APP_PASSWORD'],  #アプリパスワード
     authentication: :login
   }
+
+  # Active JobでもURLヘルパーを使うために、default_urlを設定
+  config.action_controller.default_url_options = {  host: 'torikomi.herokuapp.com' }
 end

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -49,5 +49,5 @@ ja:
     schedule:
       status:
         draft: '下書き'
-        to_be_sent: '送信予約中'
+        to_be_sent: '送信予約'
         sent: '送信済'

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -37,10 +37,6 @@ ja:
       login_type:
         default: 'デフォルト'
         google: 'Google'
-    line_user:
-      status:
-        notification_on: '通知オン'
-        notification_off: '通知オフ'
     setting:
       message_option:
         only_time: '開始日時のみ'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,7 +39,7 @@ Rails.application.routes.draw do
   resources :google_calendar_tokens, only: :destroy
 
   # LINEユーザー
-  resources :line_users, only: %i(index update destroy)
+  resources :line_users, only: %i(index destroy)
   get '/api/line_login/callback', to: 'api/line_login_api#callback'
   get '/api/line_login/:link_token/login', to: 'api/line_login_api#login', as: 'api_login'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,7 +47,8 @@ Rails.application.routes.draw do
   resource :setting, only: %i(show edit update)
 
   # Googleカレンダー連携設定
-  resource :google_calendar_setting, only: %i(show edit update)
+  # resource :google_calendar_setting, only: %i(show edit update)
+  resource :google_calendar_setting, only: :show
 
   # お問い合わせ
   resources :inquiries, only: %i(new create)

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -9,3 +9,6 @@
   access_route_page:
     cron: '0 0/20 * * * *'
     class: AccessRoutePageJob
+  update_schedules_from_google_calendar:
+    cron: '0 0 0 * * *'
+    class: UpdateSchedulesFromGoogleCalendarJob

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,6 +3,9 @@
   delete_old_schedules:
     cron: '0 0 0 * * *'
     class: DeleteOldSchedulesJob
+  # delete_draft_schedules:
+  #   cron: '0 0 0 * * *'
+  #   class: DeleteDraftSchedulesJob
   delete_old_link_tokens:
     cron: '0 0 0 * * *'
     class: DeleteOldLinkTokensJob

--- a/db/migrate/20221012143333_remove_status_from_line_users.rb
+++ b/db/migrate/20221012143333_remove_status_from_line_users.rb
@@ -1,0 +1,5 @@
+class RemoveStatusFromLineUsers < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :line_users, :status, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_18_144239) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_12_143333) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -49,7 +49,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_18_144239) do
     t.string "picture_url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "status", default: 0, null: false
     t.index ["line_user_id"], name: "index_line_users_on_line_user_id", unique: true
   end
 


### PR DESCRIPTION
# issue
close #113

# 内容
・連携中のGoogleカレンダーからスケジュールを取得する機能を追加した。
　・Googleカレンダーのイベントをすべて取得するジョブを作成し、毎日0時に実行するようにした。
　・Googleカレンダーの取得曜日・取得時間帯の設定に関連する部分をコメントアウト（一部削除）した。
　・そのスケジュールを通知するかどうかは、スケジュールのステータス（下書き／送信予約）によって判断されるようにした。
・LINEユーザーのステータス（通知オン／通知オフ）カラムを削除した。

# 備考
・Vueを多用しているスケジュール一覧ページの表示崩れを防ぐため、スケジュールの削除ボタンの確認ダイアログを削除した。