### PR TITLE
Update: herokuのプラン変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # トリコミ - リモートワーカー向けスケジュール共有サービス
 
-https://torikomi.herokuapp.com/
+https://www.torikomi.net
 
-[![ogp.jpeg](https://qiita-image-store.s3.ap-northeast-1.amazonaws.com/0/2730434/adfcdaf2-03d1-9222-5f7c-3040e23bf76e.jpeg)](https://torikomi.herokuapp.com/)
+[![ogp.jpeg](https://qiita-image-store.s3.ap-northeast-1.amazonaws.com/0/2730434/adfcdaf2-03d1-9222-5f7c-3040e23bf76e.jpeg)](https://www.torikomi.net)
 
 ## サービス概要
 

--- a/app/jobs/access_route_page_job.rb
+++ b/app/jobs/access_route_page_job.rb
@@ -3,7 +3,7 @@ class AccessRoutePageJob < ApplicationJob
   queue_as :default
 
   def perform
-    url = 'https://torikomi.herokuapp.com'
+    url = 'https://www.torikomi.net'
     response = Typhoeus::Request.get(url)
   end
 

--- a/app/views/static_pages/faq.html.slim
+++ b/app/views/static_pages/faq.html.slim
@@ -12,7 +12,7 @@
         | Googleカレンダーをアプリで使うためにはGoogleによる審査が必要なのですが、それがまだ終わっていないためにこのような警告画面が出ます。開発者を信頼していただける場合は、左下の「詳細」からGoogleカレンダー連携操作を続行できます。
       = image_tag 'google_calendar_info1.png', width: '400'
       p.py-2
-        | 「torikomi.herokuapp.com（安全ではないページへ移動）」をクリックし、その先の承認画面で承認してください。
+        | 「www.torikomi.net（安全ではないページへ移動）」をクリックし、その先の承認画面で承認してください。
       = image_tag 'google_calendar_info2.png', width: '400'
     .tr-faq.mb-12
       h2.text-2xl.font-bold.mb-3

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -92,7 +92,7 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   # パスワードリセット処理時、Gmailからメールを送信できるようにする
-  config.action_mailer.default_url_options = {  host: 'torikomi.herokuapp.com' }
+  config.action_mailer.default_url_options = {  host: 'www.torikomi.net' }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
     address: 'smtp.gmail.com',
@@ -104,5 +104,5 @@ Rails.application.configure do
   }
 
   # Active JobでもURLヘルパーを使うために、default_urlを設定
-  config.action_controller.default_url_options = {  host: 'torikomi.herokuapp.com' }
+  config.action_controller.default_url_options = {  host: 'www.torikomi.net' }
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,15 +3,9 @@
   delete_old_schedules:
     cron: '0 0 0 * * *'
     class: DeleteOldSchedulesJob
-  # delete_draft_schedules:
-  #   cron: '0 0 0 * * *'
-  #   class: DeleteDraftSchedulesJob
   delete_old_link_tokens:
     cron: '0 0 0 * * *'
     class: DeleteOldLinkTokensJob
-  access_route_page:
-    cron: '0 0/20 * * * *'
-    class: AccessRoutePageJob
   update_schedules_from_google_calendar:
     cron: '0 0 0 * * *'
     class: UpdateSchedulesFromGoogleCalendarJob


### PR DESCRIPTION
# issue
close #17 

# 内容
・Herokuにおいて、Freeプランで使えるDynoの稼働時間をオーバーしたため、Hobbyプランにアップデート
・Hobbyプランでは独自ドメインのSSL化ができるたため、`https://www.torikomi.net`をメインのドメインに変更した
・HobbyプランではDynoがスリープしないため、`AccessRoutePageJob`の定期実行を解除した