### PR TITLE
Change: Googleカレンダーのトークン処理の変更

### DIFF
--- a/app/controllers/api/google_calendar_api_controller.rb
+++ b/app/controllers/api/google_calendar_api_controller.rb
@@ -25,7 +25,7 @@ class Api::GoogleCalendarApiController < ApplicationController
       service.authorization = @auth_client
 
       google_calendar_token = GoogleCalendarToken.find_or_initialize_by(user: current_user)
-      google_calendar_token.assign_attributes(access_token: @auth_client.access_token, refresh_token: @auth_client.refresh_token, expires_at: @auth_client.expires_at, google_calendar_id: service.get_calendar('primary').id)
+      google_calendar_token.assign_attributes(refresh_token: @auth_client.refresh_token, google_calendar_id: service.get_calendar('primary').id)
 
       if google_calendar_token.save
         set_service = GoogleCalendar::ScheduleSetService.new(current_user, @auth_client)

--- a/app/models/google_calendar_token.rb
+++ b/app/models/google_calendar_token.rb
@@ -1,8 +1,6 @@
 class GoogleCalendarToken < ApplicationRecord
   belongs_to :user
 
-  validates :access_token, presence: true
   validates :refresh_token, presence: true
-  validates :expires_at, presence: true
   validates :google_calendar_id, presence: true
 end

--- a/app/services/google_calendar/schedule_set_service.rb
+++ b/app/services/google_calendar/schedule_set_service.rb
@@ -9,14 +9,9 @@ class GoogleCalendar::ScheduleSetService
 
   def call
 
-    # access_tokenが期限切れの場合は、refresh_tokenを使って新しいaccess_tokenを取得する
+    # refresh_tokenを使って新しいaccess_tokenを取得する
     @auth_client.refresh_token = @user.google_calendar_token[:refresh_token]
-    if @user.google_calendar_token.expires_at < Time.zone.now
-      @auth_client.refresh!
-      @user.google_calendar_token.update!(access_token: @auth_client.access_token, expires_at: @auth_client.expires_at)
-    else
-      @auth_client.access_token = @user.google_calendar_token[:access_token]
-    end
+    @auth_client.refresh!
 
     @service = Google::Apis::CalendarV3::CalendarService.new
     @service.authorization = @auth_client

--- a/db/migrate/20221105114709_remove_access_token_column_from_google_calendar_tokens.rb
+++ b/db/migrate/20221105114709_remove_access_token_column_from_google_calendar_tokens.rb
@@ -1,0 +1,6 @@
+class RemoveAccessTokenColumnFromGoogleCalendarTokens < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :google_calendar_tokens, :access_token, :string
+    remove_column :google_calendar_tokens, :expires_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_28_063524) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_05_114709) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -34,9 +34,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_28_063524) do
 
   create_table "google_calendar_tokens", force: :cascade do |t|
     t.bigint "user_id", null: false
-    t.string "access_token", null: false
     t.string "refresh_token", null: false
-    t.datetime "expires_at", precision: nil, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "google_calendar_id", null: false


### PR DESCRIPTION
# 内容
セキュリティ上の観点から、Googleカレンダーのアクセストークンはデータベースへ保存せず、リフレッシュトークンのみを保存するように変更。
Googleカレンダーからスケジュールを自動で取得する際は、リフレッシュトークンからアクセストークンを生成する。

# 備考
Google APIのリフレッシュトークンの有効期限はおそらく無し。
https://groups.google.com/g/google-apps-api-japan/c/kvKDfaQfvvI
アクセストークンの有効期限は1時間。
アクセストークンとリフレッシュトークンの違いについて。
https://tech-lab.sios.jp/archives/25470