### PR TITLE
Sidekiqにリトライしない設定を追加

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -66,7 +66,7 @@ Rails.application.configure do
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -5,3 +5,5 @@ end
 Sidekiq.configure_client do |config|
   config.redis = { url: ENV['REDIS_URL'] }
 end
+
+Sidekiq.default_worker_options = { 'retry' => 0 }


### PR DESCRIPTION
- Googleカレンダー取得などが失敗したときに、Sidekiqがリトライし続けてRedisの容量が逼迫するため
- 一時的にリトライを0回に